### PR TITLE
Added protocol to GA url so it uses http: when being loaded from file:

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ var reactGA = {
       a.src = g;
       m.parentNode.insertBefore(a, m)
     })(window, document, 'script',
-       '//www.google-analytics.com/analytics.js', 'ga');
+       'http' + (window.location.protocol === 'https:' ? 's' : '') + '://www.google-analytics.com/analytics.js', 'ga');
     /* jshint ignore:end */
 
     ga('create', gaTrackingID, 'auto');


### PR DESCRIPTION
I'm using react-ga in a WebView inside an app. The file will be loaded locally which means the protocol is ```file:``` so it will look for ```file://www.google-analytics.com/analytics.js```. I added a check to see if the file is being loaded from ```https:``` and if it isn't always use ```http:```.