### PR TITLE
Add ga options and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ ga.initialize('UA-000000-01', options);
 
 See example above for use with `react-router`.
 
+#### ga.set(fieldsObject)
+
+###### Example
+
+```js
+ga.set({ userId: 123 });
+```
+
+|Value|Notes|
+|------|-----|
+|fieldsObject|`Object`. e.g. `{ userId: 123 }`|
+
 #### ga.pageview(path)
 
 ###### Example

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ GA must be initialized using this function before any of the other tracking func
 ###### Example
 
 ```js
-var options = { debug: true };
+var options = { debug: true, gaOptions: { userId: 123 } };
 ga.initialize('UA-000000-01', options);
 ```
 
@@ -58,6 +58,7 @@ ga.initialize('UA-000000-01', options);
 |------|-----|
 |gaTrackingID| `String`. GA Tracking ID like 'UA-000000-01'|
 |options.debug| `Boolean`. Optional. If set to `true`, will output additional feedback to the console|
+|options.gaOptions| `Object`. Optional. [GA configurable fields.](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference)|
 
 See example above for use with `react-router`.
 

--- a/src/index.js
+++ b/src/index.js
@@ -115,8 +115,34 @@ var reactGA = {
 
   },
 
-  set: function(name, value) {
-    ga('set', name, value);
+  /**
+   * set:
+   * GA tracker set method
+   * @param {Object} fieldsObject - a field/value pair or a group of field/value pairs on the tracker
+   */
+  set: function(fieldsObject) {
+    if (typeof ga === 'function') {
+      if (!fieldsObject) {
+        warn('`fieldsObject` is required in .set()');
+        return;
+      }
+
+      if (typeof fieldsObject !== 'object') {
+        warn('Expected `fieldsObject` arg to be an Object');
+        return;
+      }
+
+      if (Object.keys(fieldsObject).length === 0) {
+        warn('empty `fieldsObject` given to .set()');
+      }
+
+      ga('set', fieldsObject);
+
+      if (_debug) {
+        log('called ga(\'set\', fieldsObject);');
+        log('with fieldsObject: ' + JSON.stringify(fieldsObject));
+      }
+    }
   },
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -62,13 +62,14 @@ function toTitleCase(s){
 }
 
 // See if s could be an email address. We don't want to send personal data like email.
+// https://support.google.com/analytics/answer/2795983?hl=en
 function mightBeEmail(s) {
   // There's no point trying to validate rfc822 fully, just look for ...@...
   return (/[^@]+@[^@]+/).test(s);
 }
 
 function format(s) {
-  if(mightBeEmail(s)) {
+  if (mightBeEmail(s)) {
     warn("This arg looks like an email address, redacting.");
     s = _redacted;
     return s;
@@ -106,7 +107,16 @@ var reactGA = {
        '//www.google-analytics.com/analytics.js', 'ga');
     /* jshint ignore:end */
 
-    ga('create', gaTrackingID, 'auto');
+    if (options && options.gaOptions) {
+      ga('create', gaTrackingID, options.gaOptions);
+    } else {
+      ga('create', gaTrackingID, 'auto');
+    }
+
+  },
+
+  set: function(name, value) {
+    ga('set', name, value);
   },
 
   /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -53,6 +53,11 @@ describe('react-ga', function() {
       getGaCalls().should.eql([['create', 'foo', 'auto']]);
     });
 
+    it('should call window.ga() with ga options if they are given', function() {
+      ga.initialize('foo', { gaOptions: { userId: 123 } });
+      getGaCalls().should.eql([['create', 'foo', { userId: 123 }]]);
+    });
+
     it('should abort, log warning if tracking ID is not given', function() {
       ga.initialize();
       console.warn.args.should.eql([[
@@ -68,7 +73,7 @@ describe('react-ga', function() {
 
   describe('pageview()', function() {
 
-    it('should output degug info, if debug is on', function() {
+    it('should output debug info, if debug is on', function() {
       var options = { debug: true };
       ga.initialize('foo', options);
       ga.pageview('/valid');
@@ -116,7 +121,7 @@ describe('react-ga', function() {
 
   describe('modalview()', function() {
 
-    it('should output degug info, if debug is on', function() {
+    it('should output debug info, if debug is on', function() {
       var options = { debug: true };
       ga.initialize('foo', options);
       ga.modalview('valid');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -68,6 +68,55 @@ describe('react-ga', function() {
   });
 
   /**
+   * set()
+   */
+
+  describe('set()', function() {
+
+    it('should output debug info, if debug is on', function() {
+      var options = { debug: true };
+      ga.initialize('foo', options);
+      ga.set( { userId: 123 } );
+      console.info.args.should.eql([
+        [ "[react-ga]", "called ga('set', fieldsObject);" ],
+        [ "[react-ga]", "with fieldsObject: {\"userId\":123}" ]
+      ]);
+    });
+
+    it('should warn if fieldsObject object is missing', function() {
+      ga.initialize('foo');
+      ga.set();
+      console.warn.args.should.eql([[
+        '[react-ga]', '`fieldsObject` is required in .set()'
+      ]]);
+    });
+
+    it('should warn if fieldsObject is not an Object', function() {
+      ga.initialize('foo');
+      ga.set(123);
+      console.warn.args.should.eql([[
+        '[react-ga]', 'Expected `fieldsObject` arg to be an Object'
+      ]]);
+    });
+
+    it('should warn if fieldsObject object is an empty object', function() {
+      ga.initialize('foo');
+      ga.set( {} );
+      console.warn.args.should.eql([[
+        '[react-ga]', 'empty `fieldsObject` given to .set()'
+      ]]);
+    });
+
+    it('should set the field values', function() {
+      ga.initialize('foo');
+      ga.set( { userId: 123 } );
+      getGaCalls().should.eql([ [ 'create', 'foo', 'auto' ],
+                                [ 'set', { userId: 123 }]
+                                ]);
+    });
+  });
+
+  /**
    * pageview()
    */
 


### PR DESCRIPTION
Modified from #28 by @mrsln but with tests. Figured I would add the tests since #28 is inactive.

Also added a more robust implementation of `ga.set()` along with tests and documentation