### PR TITLE
Optional use case of execute() with actionType and payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ ga.plugin.require('ecommerce');
 ```
 
 
-#### ga.plugin.execute(pluginName, action, payload)
+#### ga.plugin.execute(pluginName, action, [actionType], [payload])
 
 Execute the `action` for the `pluginName` with the payload.
 
@@ -202,6 +202,18 @@ ga.plugin.execute('ecommerce', 'addTransaction', {
   revenue: '3.50'
 });
 ```
+
+You can use this function with four arguments to pass `actionType` and `payload` along with executed action
+
+#### Example
+
+```js
+ga.plugin.execute('ec', 'setAction', 'purchase', {
+  id: 'jd38je31j',
+  revenue: '3.50'
+});
+```
+
 ---
 
 ## Development

--- a/src/index.js
+++ b/src/index.js
@@ -330,10 +330,10 @@ var reactGA = {
       var payload, actionType;
 
       if (args.length === 3) {
-        payload = args[2]
+        payload = args[2];
       } else {
-        actionType = args[2]
-        payload = args[3]
+        actionType = args[2];
+        payload = args[3];
       }
 
       if (typeof ga === 'function') {

--- a/src/index.js
+++ b/src/index.js
@@ -349,7 +349,7 @@ var reactGA = {
             ga(command, actionType, payload);
             if (_debug) {
               log('called ga(\'' + command + '\');');
-              log('actionType: ' + actionType + ' with payload: ' + JSON.stringify(payload));
+              log('actionType: "' + actionType + '" with payload: ' + JSON.stringify(payload));
             }
           } else if (payload) {
             ga(command, payload);

--- a/src/index.js
+++ b/src/index.js
@@ -317,14 +317,15 @@ var reactGA = {
     /**
      * execute:
      * GA execute action for plugin
-     * @param var_args {...*} Variable number of arguments
-     * @param var_args[0] {String} Plugin name, e.g. 'ecommerce' or 'myplugin'
-     * @param var_args[1] {String} Action name, e.g. 'addItem' or 'myCustomAction'
-     * @param var_args[2] {Object} optional Action type e.g 'detail' OR Payload e.g { id: '1x5e', name : 'My product to track' }
-     * @param var_args[3] {Object} optional Payload e.g { id: '1x5e', name : 'My product to track' }
+     * Takes variable number of arguments
+     * @param pluginName {String} e.g. 'ecommerce' or 'myplugin'
+     * @param action {String} e.g. 'addItem' or 'myCustomAction'
+     * @param actionType {String} optional e.g. 'detail'
+     * @param payload {Object} optional e.g { id: '1x5e', name : 'My product to track' }
      */
-    execute: function (var_args) {
+    execute: function () {
       var args = Array.prototype.slice.call(arguments);
+
       var pluginName = args[0];
       var action = args[1];
       var payload, actionType;

--- a/src/index.js
+++ b/src/index.js
@@ -317,11 +317,25 @@ var reactGA = {
     /**
      * execute:
      * GA execute action for plugin
-     * @param pluginName {String} e.g. 'ecommerce' or 'myplugin'
-     * @param action {String} e.g. 'addItem' or 'myCustomAction'
-     * @param payload {Object} optional e.g { id: '1x5e', name : 'My product to track' }
+     * @param var_args {...*} Variable number of arguments
+     * @param var_args[0] {String} Plugin name, e.g. 'ecommerce' or 'myplugin'
+     * @param var_args[1] {String} Action name, e.g. 'addItem' or 'myCustomAction'
+     * @param var_args[2] {Object} optional Action type e.g 'detail' OR Payload e.g { id: '1x5e', name : 'My product to track' }
+     * @param var_args[3] {Object} optional Payload e.g { id: '1x5e', name : 'My product to track' }
      */
-    execute: function (pluginName, action, payload) {
+    execute: function (var_args) {
+      var args = Array.prototype.slice.call(arguments);
+      var pluginName = args[0];
+      var action = args[1];
+      var payload, actionType;
+
+      if (args.length === 3) {
+        payload = args[2]
+      } else {
+        actionType = args[2]
+        payload = args[3]
+      }
+
       if (typeof ga === 'function') {
         if (typeof pluginName !== 'string') {
           warn('Expected `pluginName` arg to be a String.');
@@ -330,7 +344,13 @@ var reactGA = {
         } else {
           var command = pluginName + ':' + action;
           payload = payload || null;
-          if (payload) {
+          if (actionType && payload) {
+            ga(command, actionType, payload);
+            if (_debug) {
+              log('called ga(\'' + command + '\');');
+              log('actionType: ' + actionType + ' with payload: ' + JSON.stringify(payload));
+            }
+          } else if (payload) {
             ga(command, payload);
             if (_debug) {
               log('called ga(\'' + command + '\');');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -575,6 +575,15 @@ describe('react-ga', function () {
          ['ecommerce:send']
        ]);
      });
+
+     it('should execute ec:setAction \'checkout\' with payload { \'step\': 1 }', function() {
+       ga.initialize('plugin');
+       ga.plugin.execute('ec', 'setAction', 'checkout', { step: 1 });
+       getGaCalls().should.eql([
+         ['create', 'plugin', 'auto'],
+         ['ec:setAction', 'checkout', { step: 1 }]
+       ]);
+     });
    });
 
 });


### PR DESCRIPTION
Allow (3..4) number of arguments in execute() to accept optional actionType with payload
Fixes #41 (Issue is described by @irrg in all details)

This is widely used in `enhanced-commerce` plugin: https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#checkout-process

Couldn't figure out how to describe changes in Readme. Help needed :)