### PR TITLE
GA plugin args support

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ ga.exception( { description: 'An error ocurred', fatal: true } );
 |args.fatal|`String`. Optional. Set to `true` if it was a fatal exception.|
 
 
-#### ga.plugin.require(name, options)
+#### ga.plugin.require(name, [options])
 
 Require GA plugins.
 

--- a/README.md
+++ b/README.md
@@ -168,14 +168,19 @@ ga.exception( { description: 'An error ocurred', fatal: true } );
 |args.fatal|`String`. Optional. Set to `true` if it was a fatal exception.|
 
 
-#### ga.plugin.require(name)
+#### ga.plugin.require(name, options)
 
 Require GA plugins.
 
 ##### Example
 ```js
-ga.plugin.require('ecommerce');
+ga.plugin.require('localHitSender', {path: '/log', debug: true});
 ```
+
+|Value|Notes|
+|------|-----|
+|name|`String`. Required. The name of the plugin to be required. Note: if the plugin is not an official analytics.js plugin, it must be provided elsewhere on the page.|
+|options|`Object`. Optional. An initialization object that will be passed to the plugin constructor upon instantiation.|
 
 
 #### ga.plugin.execute(pluginName, action, payload)

--- a/src/index.js
+++ b/src/index.js
@@ -306,11 +306,44 @@ var reactGA = {
      */
     require: function(name, options) {
       if (typeof ga === 'function') {
-        ga('require', name, options);
-      }
 
-      if (_debug) {
-        log('called ga(\'require\', \'' + name + '\', ' + JSON.stringify(options) + ');');
+        // Required Fields
+        if (!name) {
+          warn('name is required in .require()');
+          return;
+        }
+
+        name = trim(name);
+        if (path === '') {
+          warn('name cannot be an empty string in .require()');
+          return;
+        }
+
+        // Optional Fields
+        if (options) {
+          if (typeof options !== 'object') {
+            warn('Expected `options` arg to be an Object');
+            return;
+          }
+
+          if (Object.keys(options).length === 0) {
+            warn('empty `options` given to .require()');
+          }
+
+          ga('require', name, options);
+
+          if (_debug) {
+            log('called ga(\'require\', \'' + name + '\', ' + JSON.stringify(options) + ');');
+          }
+          return;
+        } else {
+          ga('require', name);
+
+          if (_debug) {
+            log('called ga(\'require\', \'' + name + '\');');
+          }
+          return;
+        }
       }
     },
 

--- a/src/index.js
+++ b/src/index.js
@@ -305,7 +305,6 @@ var reactGA = {
      * @param name {String} e.g. 'ecommerce' or 'myplugin'
      * @param options {Object} optional e.g {path: '/log', debug: true}
      */
-<<<<<<< HEAD
     require: function (name, options) {
       if (typeof ga === 'function') {
 

--- a/src/index.js
+++ b/src/index.js
@@ -302,15 +302,15 @@ var reactGA = {
      * require:
      * GA requires a plugin
      * @param name {String} e.g. 'ecommerce' or 'myplugin'
-     * @param args {Object} optional e.g {path: '/log', debug: true}
+     * @param options {Object} optional e.g {path: '/log', debug: true}
      */
-    require: function(name, args) {
+    require: function(name, options) {
       if (typeof ga === 'function') {
-        ga('require', name, args);
+        ga('require', name, options);
       }
 
       if (_debug) {
-        log('called ga(\'require\', \'' + name + '\', ' + JSON.stringify(args) + ');');
+        log('called ga(\'require\', \'' + name + '\', ' + JSON.stringify(options) + ');');
       }
     },
 

--- a/src/index.js
+++ b/src/index.js
@@ -302,14 +302,15 @@ var reactGA = {
      * require:
      * GA requires a plugin
      * @param name {String} e.g. 'ecommerce' or 'myplugin'
+     * @param args {Object} optional e.g {path: '/log', debug: true}
      */
-    require: function(name) {
+    require: function(name, args) {
       if (typeof ga === 'function') {
-        ga('require', name);
+        ga('require', name, args);
       }
 
       if (_debug) {
-        log('called ga(\'require\', \'' + name + '\');');
+        log('called ga(\'require\', \'' + name + '\', ' + JSON.stringify(args) + ');');
       }
     },
 

--- a/src/index.js
+++ b/src/index.js
@@ -336,6 +336,7 @@ var reactGA = {
           if (_debug) {
             log('called ga(\'require\', \'' + name + '\', ' + JSON.stringify(options) + ');');
           }
+
           return;
         } else {
           ga('require', name);
@@ -343,6 +344,7 @@ var reactGA = {
           if (_debug) {
             log('called ga(\'require\', \'' + name + '\');');
           }
+          
           return;
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -344,7 +344,7 @@ var reactGA = {
           if (_debug) {
             log('called ga(\'require\', \'' + name + '\');');
           }
-          
+
           return;
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -310,13 +310,13 @@ var reactGA = {
 
         // Required Fields
         if (!name) {
-          warn('name is required in .require()');
+          warn('`name` is required in .require()');
           return;
         }
 
         name = trim(name);
-        if (path === '') {
-          warn('name cannot be an empty string in .require()');
+        if (name === '') {
+          warn('`name` cannot be an empty string in .require()');
           return;
         }
 
@@ -328,7 +328,7 @@ var reactGA = {
           }
 
           if (Object.keys(options).length === 0) {
-            warn('empty `options` given to .require()');
+            warn('Empty `options` given to .require()');
           }
 
           ga('require', name, options);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -576,13 +576,13 @@ describe('react-ga', function () {
        ]);
      });
 
-     it('should require plugin: localHitSender', function() {
+     it('should require plugin: localHitSender', function () {
        ga.initialize('plugin');
-       ga.plugin.require('localHitSender', {path: '/log', debug: true});
+       ga.plugin.require('localHitSender', { path: '/log', debug: true });
 
        getGaCalls().should.eql([
          ['create', 'plugin', 'auto'],
-         ['require', 'localHitSender', {path: '/log', debug: true}]
+         ['require', 'localHitSender', { path: '/log', debug: true }]
        ]);
      });
    });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -570,6 +570,16 @@ describe('react-ga', function() {
          ['ecommerce:send']
        ]);
      });
+
+     it('should require plugin: localHitSender', function() {
+       ga.initialize('plugin');
+       ga.plugin.require('localHitSender', {path: '/log', debug: true});
+
+       getGaCalls().should.eql([
+         ['create', 'plugin', 'auto'],
+         ['require', 'ecommerce', {path: '/log', debug: true}]
+       ]);
+     });
    });
 
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -582,7 +582,7 @@ describe('react-ga', function () {
 
        getGaCalls().should.eql([
          ['create', 'plugin', 'auto'],
-         ['require', 'ecommerce', {path: '/log', debug: true}]
+         ['require', 'localHitSender', {path: '/log', debug: true}]
        ]);
      });
    });


### PR DESCRIPTION
In [analytics.js documentation](https://developers.google.com/analytics/devguides/collection/analyticsjs/command-queue-reference#require) `require` command takes `pluginName` and optionally `pluginOptions`:
`ga('[trackerName.]require', pluginName, [pluginOptions]);`
while react-ga supports only `pluginName` :(

Added support for `pluginOptions`.