### PR TITLE
changes Object.assign dependency to use npm package `object-assign`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jsdom": "^3.0.0",
     "mocha": "^2.2.1",
     "mocha-jsdom": "~1.0.0",
+    "object-assign": "^4.0.1",
     "react": "^0.13.1",
     "should": "^5.2.0",
     "sinon": "^1.14.1"

--- a/src/components/OutboundLink.js
+++ b/src/components/OutboundLink.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var assign = require('react/lib/Object.assign');
+var assign = require('object-assign');
 
 var NEWTAB = '_blank';
 


### PR DESCRIPTION
Fixes react-ga/react-ga/#53

Changes OutboundLink.js to no longer reference internal files in react module's lib directory. Instead, references the public package `object-assign` (which is what React v15 is using now as well).