### PR TITLE
Make titleCase strings optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,20 @@ GA must be initialized using this function before any of the other tracking func
 ###### Example
 
 ```js
-var options = { debug: true, gaOptions: { userId: 123 } };
-ga.initialize('UA-000000-01', options);
+ga.initialize('UA-000000-01', {
+  debug: true,
+  titleCase: false,
+  gaOptions: {
+    userId: 123
+  }
+});
 ```
 
 |Value|Notes|
 |------|-----|
-|gaTrackingID| `String`. GA Tracking ID like 'UA-000000-01'.|
+|gaTrackingID| `String`. Required. GA Tracking ID like `UA-000000-01`.|
 |options.debug| `Boolean`. Optional. If set to `true`, will output additional feedback to the console.|
+|options.titleCase| `Boolean`. Optional. Defaults to `true`. If set to `false`, strings will not be converted to title case before sending to GA.|
 |options.gaOptions| `Object`. Optional. [GA configurable fields.](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference)|
 
 See example above for use with `react-router`.

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,11 @@ var warn = require('./utils/console/warn');
 var log = require('./utils/console/log');
 
 var _debug = false;
+var _titleCase = true;
+
+var _format = function (s) {
+  return format(s, _titleCase);
+};
 
 var ReactGA = {
   initialize: function (gaTrackingID, options) {
@@ -28,6 +33,10 @@ var ReactGA = {
     if (options) {
       if (options.debug && options.debug === true) {
         _debug = true;
+      }
+
+      if (options.titleCase === false) {
+        _titleCase = false;
       }
     }
 
@@ -164,13 +173,13 @@ var ReactGA = {
       // Required Fields
       var fieldObject = {
         hitType: 'event',
-        eventCategory: format(args.category),
-        eventAction: format(args.action)
+        eventCategory: _format(args.category),
+        eventAction: _format(args.action)
       };
 
       // Optional Fields
       if (args.label) {
-        fieldObject.eventLabel = format(args.label);
+        fieldObject.eventLabel = _format(args.label);
       }
 
       if (args.value) {
@@ -215,7 +224,7 @@ var ReactGA = {
 
       // Optional Fields
       if (args.description) {
-        fieldObject.exDescription = format(args.description);
+        fieldObject.exDescription = _format(args.description);
       }
 
       if (typeof args.fatal !== 'undefined') {
@@ -369,7 +378,7 @@ var ReactGA = {
         hitType: 'event',
         eventCategory: 'Outbound',
         eventAction: 'Click',
-        eventLabel: format(args.label)
+        eventLabel: _format(args.label)
       };
 
       var safetyCallbackCalled = false;

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -4,14 +4,16 @@ var warn = require('./console/warn');
 
 var _redacted = 'REDACTED (Potential Email Address)';
 
-function format(s) {
+function format(s, titleCase) {
   if (mightBeEmail(s)) {
     warn('This arg looks like an email address, redacting.');
-    s = _redacted;
-    return s;
+    return _redacted;
   }
 
-  s = toTitleCase(s);
+  if (titleCase) {
+    return toTitleCase(s);
+  }
+
   return s;
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -75,8 +75,7 @@ describe('react-ga', function () {
   describe('set()', function () {
 
     it('should output debug info, if debug is on', function () {
-      var options = { debug: true };
-      ga.initialize('foo', options);
+      ga.initialize('foo', { debug: true });
       ga.set({ userId: 123 });
       console.info.args.should.eql([
         ['[react-ga]', "called ga('set', fieldsObject);"],
@@ -289,6 +288,28 @@ describe('react-ga', function () {
       getGaCalls().should.eql([['create', 'foo', 'auto'],
                                 ['send', { eventAction: 'Send Test',
                                             eventCategory: 'Test',
+                                            hitType: 'event'
+                                          }]
+                                ]);
+    });
+
+    it('should record an event with strings converted to titleCase', function () {
+      ga.initialize('foo');
+      ga.event({ category: 'test', action: 'send test' });
+      getGaCalls().should.eql([['create', 'foo', 'auto'],
+                                ['send', { eventAction: 'Send Test',
+                                            eventCategory: 'Test',
+                                            hitType: 'event'
+                                          }]
+                                ]);
+    });
+
+    it('should not convert strings to titleCase if the flag is false', function () {
+      ga.initialize('foo', { titleCase: false });
+      ga.event({ category: 'test', action: 'send test' });
+      getGaCalls().should.eql([['create', 'foo', 'auto'],
+                                ['send', { eventAction: 'send test',
+                                            eventCategory: 'test',
                                             hitType: 'event'
                                           }]
                                 ]);

--- a/test/utils/format.test.js
+++ b/test/utils/format.test.js
@@ -17,12 +17,19 @@ describe('format()', function () {
   });
 
   it('should format non-email addresses', function () {
-    format('mystring').should.eql('Mystring');
-    format('foo bar').should.eql('Foo Bar');
-    format('foo_bar').should.eql('Foo_bar');
+    format('mystring').should.eql('mystring');
+    format('mystring', true).should.eql('Mystring');
+    format('foo bar').should.eql('foo bar');
+    format('foo bar', true).should.eql('Foo Bar');
+    format('foo_bar').should.eql('foo_bar');
+    format('foo_bar', true).should.eql('Foo_bar');
     format('foo.bar').should.eql('foo.bar');
+    format('foo.bar', true).should.eql('foo.bar');
     format('FOO_BAR').should.eql('FOO_BAR');
+    format('FOO_BAR', true).should.eql('FOO_BAR');
     format('123456789').should.eql('123456789');
-    format('the quick brown fox').should.eql('The Quick Brown Fox');
+    format('123456789', true).should.eql('123456789');
+    format('the quick brown fox').should.eql('the quick brown fox');
+    format('the quick brown fox', true).should.eql('The Quick Brown Fox');
   });
 });


### PR DESCRIPTION
By popular demand, here's a PR to make `toTitleCase` conversion of strings optional. Closes #24 