### PR TITLE
Added window and ga variables to enable serverside rendering

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,9 @@ var trim = require('./utils/trim');
 var warn = require('./utils/console/warn');
 var log = require('./utils/console/log');
 
+var window = require('window-or-global');
+var ga     = null;
+
 var _debug = false;
 var _titleCase = true;
 
@@ -54,6 +57,10 @@ var ReactGA = {
       m.parentNode.insertBefore(a, m);
     })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
     // jscs:enable
+
+	if(!ga){
+		ga = window.ga;
+	}
 
     if (options && options.gaOptions) {
       ga('create', gaTrackingID, options.gaOptions);


### PR DESCRIPTION
Hi guys, I was making my own thin client on top of Google Analytics ( issue #103 ), and I was running into the same server-side rendering problems as ( #98 ). Adding the [window-or-global](https://www.npmjs.com/package/window-or-global) package worked for me to get access to the `ga` object.