### PR TITLE
Fix #116: Provided options using ga('set',...)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,11 +55,14 @@ var ReactGA = {
     })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
     // jscs:enable
 
+    ga('create', gaTrackingID, 'auto');
+
     if (options && options.gaOptions) {
-      ga('create', gaTrackingID, options.gaOptions);
-    } else {
-      ga('create', gaTrackingID, 'auto');
+      for (var prop in options.gaOptions) {
+        ga('set', prop, options.gaOptions[prop].toString());
+      }
     }
+
   },
 
   /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -56,10 +56,11 @@ describe('react-ga', function () {
       ]);
     });
 
-    it('should call window.ga() with ga options if they are given', function () {
+    it('should set options using window.ga() when they are provided', function () {
       ReactGA.initialize('foo', { gaOptions: { userId: 123 } });
       getGaCalls().should.eql([
-        ['create', 'foo', { userId: 123 }]
+        ['create', 'foo', 'auto'],
+        ['set', 'userId', '123']
       ]);
     });
 


### PR DESCRIPTION
- Update `initialize()` to loop through the provided options, calling `ga('set', {optName}, {optValue});`
- Update related unit test to match new logic
