### PR TITLE
add create-react-class and prop-types deps, since they're deprecated …

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "react": ">= 0.14.0"
   },
   "dependencies": {
-    "object-assign": "^4.0.1"
+    "create-react-class": "^15.5.2",
+    "object-assign": "^4.0.1",
+    "prop-types": "^15.5.6"
   },
   "devDependencies": {
     "browserify": "^13.0.0",

--- a/src/components/OutboundLink.js
+++ b/src/components/OutboundLink.js
@@ -1,12 +1,14 @@
 var React = require('react');
+var CreateReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 var assign = require('object-assign');
 
 var NEWTAB = '_blank';
 
-var OutboundLink = React.createClass({
+var OutboundLink = CreateReactClass({
   displayName: 'OutboundLink',
   propTypes: {
-    eventLabel: React.PropTypes.string.isRequired
+    eventLabel: PropTypes.string.isRequired
   },
   statics: {
     trackLink: function () {


### PR DESCRIPTION
…from core react as of 15.5.0

React deprecated `.PropTypes` and `.createClass` as of 15.5.0: https://github.com/facebook/react/releases/tag/v15.5.0

The former was moved into a separate project. For the latter they recommend plain ES6 classes or, failing that, an addon. This PR took the second approach, to adhere to current project conventions.