### PR TITLE
Add component for tracking an outbound link and opening in a new window

### DIFF
--- a/src/components/OutboundLinkNewWindow.js
+++ b/src/components/OutboundLinkNewWindow.js
@@ -1,0 +1,27 @@
+/* Adapted from https://github.com/react-ga/react-ga/issues/118 */
+import React, { Component } from 'react'
+import ReactGA from 'react-ga'
+
+export default class OutLinkNewWindow extends Component {
+  render () {
+    const handleOutbound = eventLabel => {
+      ReactGA.event({
+        category: 'Outbound',
+        action: 'click',
+        label: eventLabel
+      })
+    }
+
+    const { children, to, label, ...restProps } = this.props
+    return (
+      <a
+        {...restProps}
+        href={to}
+        target='_blank'
+        onClick={() => handleOutbound(label)}
+      >
+        {children}
+      </a>
+    )
+  }
+}


### PR DESCRIPTION
In regard to issues #118  #71 #91 , I created a component that successfully tracks a click on an outbound link and opens that link in a new window or tab.

I don't know how to write tests in Mocha, so I didn't write any for this new component. If this is necessary, I am willing to learn how to write them and submit another request. 

I livestreamed the process of creating this pull request. You can watch the recording for more info if needed.
[https://youtu.be/HwdkB8MXbFM](https://youtu.be/HwdkB8MXbFM)