### PR TITLE
Added option for alternative address for analytics.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ var ReactGA = {
       a.async = 1;
       a.src = g;
       m.parentNode.insertBefore(a, m);
-    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+    })(window, document, 'script', ((options && options.gaAddress) ? options.gaAddress : 'https://www.google-analytics.com/analytics.js'), 'ga');
     // jscs:enable
 
     if (Array.isArray(configs)) {


### PR DESCRIPTION
Although it is not recommended, you might prefer to host the analytics.js file yourself, instead of fetching it from Google. I've added the option gaAddress, that will replace the default address if set.