### PR TITLE
Exclude peerDependences and dependencies from the output bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const webpack = require('webpack');
 const path = require('path');
+const pkg = require('./package.json');
 
 module.exports = {
   entry: {
@@ -11,6 +12,9 @@ module.exports = {
     filename: '[name].js',
     libraryTarget: 'commonjs2'
   },
+  externals: []
+    .concat(Object.keys(pkg.peerDependencies))
+    .concat(Object.keys(pkg.dependencies)),
   module: {
     loaders: [
       { test: /\.jsx?$/, loader: 'babel-loader', exclude: /node_modules/ }


### PR DESCRIPTION
<b>React</b>, <b>prop-types</b>, and <b>object-assign</b> modules are currently included in the output bundle. To avoid unnecessary footprint, we can specify the <b>externals</b> configuration option in the webpack config to exclude <b>dependencies</b> and <b>peerDependencies</b> from the output bundle.

```js
externals: []
  .concat(Object.keys(pkg.peerDependencies))
  .concat(Object.keys(pkg.dependencies)),
```