### PR TITLE
Rename the import in demo/app/withTracker

### DIFF
--- a/demo/app/withTracker.jsx
+++ b/demo/app/withTracker.jsx
@@ -3,15 +3,15 @@
  */
 
 import React, { Component } from 'react';
-import GoogleAnalytics from '../../src';
+import ReactGA from '../../src';
 
 export default function withTracker(WrappedComponent, options = {}) {
   const trackPage = (page) => {
-    GoogleAnalytics.set({
+    ReactGA.set({
       page,
       ...options
     });
-    GoogleAnalytics.pageview(page);
+    ReactGA.pageview(page);
   };
 
   const HOC = class extends Component {


### PR DESCRIPTION
Renames the import in withTracker to be consistent with the other modules in the demo (the library is imported as `ReactGA` in the other files).

This is just a tiny change that I found made it a bit easier to understand the examples personally, but feel free to reject if you don't feel it's necessary :)

I've left out the changes in `/dist/` for now, as per the README.