### PR TITLE
add .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,4 @@ webpack.config.js
 *.log
 /coverage
 /.nyc_output
+.babelrc


### PR DESCRIPTION
```sh
./node_modules/react-ga/dist/react-ga.js
Module build failed: Error: Couldn't find preset "es2015" relative to directory "~~~/node_modules/react-ga"
```

Having `.babelrc` included inside the package directory makes the module build fail.