### PR TITLE
Update types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -276,6 +276,7 @@ export function timing({ category, variable, value, label } = {}, trackerNames) 
  * @param args.label {String} optional
  * @param args.value {Int} optional
  * @param args.nonInteraction {boolean} optional
+ * @param args.transport {string} optional
  * @param {Array} trackerNames - (optional) a list of extra trackers to run the command on
  */
 export function event({ category, action, label, value, nonInteraction, transport, ...args } = {}, trackerNames) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-ga 2.1
 // Project: https://github.com/react-ga/react-ga
-// Definitions by: Tim Aldridge <https://github.com/telshin>
+// Definitions by: Tim Aldridge <https://github.com/telshin>, Philip Karpiak <https://github.com/eswat>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface EventArgs {
@@ -9,6 +9,7 @@ export interface EventArgs {
     label?: string;
     value?: number;
     nonInteraction?: boolean;
+    transport?: string;
 }
 
 export interface GaOptions {
@@ -53,7 +54,7 @@ export interface Plugin {
 
 export interface TestModeAPI {
   calls: any[][];
-  ga: (...any) => any;
+  ga: (...any: any[]) => any;
 }
 
 export interface OutboundLinkArgs {
@@ -69,13 +70,13 @@ export interface OutboundLinkProps {
 
 export function initialize(trackingCode: string, options?: InitializeOptions): void;
 export function ga(): any;
-export function set(fieldsObject: FieldsObject): void;
-export function send(fieldsObject: FieldsObject): void;
-export function pageview(path: string): void;
-export function modalview(name: string): void;
+export function set(fieldsObject: FieldsObject, trackerNames?: string[]): void;
+export function send(fieldsObject: FieldsObject, trackerNames?: string[]): void;
+export function pageview(path: string, trackerNames?: string[], title?: string): void;
+export function modalview(name: string, trackerNames?: string[]): void;
 export function timing(args: TimingArgs): void;
-export function event(args: EventArgs): void;
-export function exception(fieldsObject: FieldsObject): void;
+export function event(args: EventArgs, trackerNames?: string[]): void;
+export function exception(fieldsObject: FieldsObject, trackerNames?: string[]): void;
 export const plugin: Plugin;
 export const testModeAPI: TestModeAPI;
 export function outboundLink(args: OutboundLinkArgs, hitCallback: () => void): void;


### PR DESCRIPTION
- Updates the type/interface definitions to match the parameters given in the actual source
- Also a small addition to the comment block above `event()` to briefly describe the transport parameter
- Also sets an explicit type inside the `TestModeAPI` interface (otherwise this will be seen as an implicit any and may break in projects that require explicit types set)