### PR TITLE
Add `trackerNames` arg to pageview documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ ReactGA.pageview('/about/contact-us');
 |Value|Notes|
 |------|-----|
 |path|`String`. e.g. '/get-involved/other-ways-to-help'|
+|trackerNames|`Array`. Optional. A list of extra trackers to run the command on|
 |title|`String`. Optional. e.g. 'Other Ways to Help'|
 
 See example above for use with `react-router`.


### PR DESCRIPTION
Since the arguments are positional, not mentioning this arguments leads to an error since the user will try to pass the `title` as the 2nd argument