### PR TITLE
Update Typescript to support Trackers

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,13 @@
-// Type definitions for react-ga 2.1
+// Type definitions for react-ga 2.4
 // Project: https://github.com/react-ga/react-ga
-// Definitions by: Tim Aldridge <https://github.com/telshin>, Philip Karpiak <https://github.com/eswat>
+// Definitions by: Tim Aldridge <https://github.com/telshin>
+//                 Philip Karpiak <https://github.com/eswat>
+//                 Jerry Reptak <https://github.com/jetfault>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import React from 'react';
+
+/* tslint:disable no-any */
 
 export interface EventArgs {
     category: string;
@@ -36,6 +42,12 @@ export interface InitializeOptions {
     gaOptions?: GaOptions;
 }
 
+export type Tracker = {
+    trackingId: string,
+} & InitializeOptions;
+
+export type TrackerNames = string[];
+
 export interface FieldsObject {
     [i: string]: any;
 }
@@ -54,7 +66,7 @@ export interface Plugin {
 
 export interface TestModeAPI {
   calls: any[][];
-  ga: (...any: any[]) => any;
+  ga: (...args: any[]) => any;
 }
 
 export interface OutboundLinkArgs {
@@ -64,20 +76,20 @@ export interface OutboundLinkArgs {
 export interface OutboundLinkProps {
     eventLabel: string;
     to: string;
-    target?: string,
-    onClick?: Function
+    target?: string;
+    onClick?: Function;
 }
 
 export function initialize(trackingCode: string, options?: InitializeOptions): void;
+export function initialize(trackers: Tracker[]): void;
 export function ga(): any;
-export function set(fieldsObject: FieldsObject, trackerNames?: string[]): void;
-export function send(fieldsObject: FieldsObject, trackerNames?: string[]): void;
-export function pageview(path: string, trackerNames?: string[], title?: string): void;
-export function modalview(name: string, trackerNames?: string[]): void;
-export function timing(args: TimingArgs): void;
-export function event(args: EventArgs, trackerNames?: string[]): void;
-export function exception(fieldsObject: FieldsObject, trackerNames?: string[]): void;
+export function set(fieldsObject: FieldsObject, trackerNames?: TrackerNames): void;
+export function send(fieldsObject: FieldsObject, trackerNames?: TrackerNames): void;
+export function pageview(path: string, trackerNames?: TrackerNames, title?: string): void;
+export function modalview(name: string, trackerNames?: TrackerNames): void;
+export function timing(args: TimingArgs, trackerNames?: TrackerNames): void;
+export function event(args: EventArgs, trackerNames?: TrackerNames): void;
+export function exception(fieldsObject: FieldsObject, trackerNames?: TrackerNames): void;
 export const plugin: Plugin;
-export const testModeAPI: TestModeAPI;
-export function outboundLink(args: OutboundLinkArgs, hitCallback: () => void): void;
+export function outboundLink(args: OutboundLinkArgs, hitCallback: () => void, trackerNames?: TrackerNames): void;
 export const OutboundLink : React.ComponentClass<OutboundLinkProps & React.HTMLProps<OutboundLinkProps>>;

--- a/types/react-ga-tests.ts
+++ b/types/react-ga-tests.ts
@@ -1,4 +1,4 @@
-import * as ga from "react-ga";
+import * as ga from "./index";
 
 declare function describe(desc: string, f: () => void): void;
 declare function it(desc: string, f: () => void): void;
@@ -14,12 +14,32 @@ describe("Testing react-ga initialize object", () => {
 
         ga.initialize("UA-65432-1", options);
     });
+
+    it("Able to initialize multiple trackers", () => {
+        ga.initialize([
+            { trackingId: "abc", debug: true},
+            { trackingId: "efg", debug: true, gaOptions: { name: "blah" }}
+        ]);
+    });
 });
 
 describe("Testing react-ga pageview calls", () => {
     it("Able to make pageview calls", () => {
         ga.initialize("UA-65432-1");
         ga.pageview("http://telshin.com");
+    });
+
+    it("Able to make pageview calls with multiple trackers", () => {
+        ga.initialize([
+            { trackingId: "abc", debug: true},
+            { trackingId: "efg", debug: true, gaOptions: { name: "blah" }}
+        ]);
+        ga.pageview("http://telshin.com", ["blah"]);
+    });
+
+    it("Able to make pageview calls with custom title", () => {
+        ga.initialize("UA-65432-1");
+        ga.pageview("http://telshin.com", null, "custom title");
     });
 });
 
@@ -29,33 +49,56 @@ describe("Testing react-ga modal calls", () => {
 
         ga.modalview("Test modal");
     });
+    it("Able to make modal calls with multiple trackers", () => {
+        ga.initialize([
+            { trackingId: "abc", debug: true},
+            { trackingId: "efg", debug: true, gaOptions: { name: "blah" }}
+        ]);
+        ga.modalview("Test modal", ["blah"]);
+    });
 });
 
 describe("Testing react-ga event calls", () => {
+    const options: ga.EventArgs = {
+        category: "Test",
+        action: "CI",
+        label: "Running Jasmine tests for react-ga typscript library",
+        value: 4,
+        nonInteraction: true,
+    };
+
     it("Able to make event calls", () => {
         ga.initialize("UA-65432-1");
 
-        const options: ga.EventArgs = {
-            category: "Test",
-            action: "CI",
-            label: "Running Jasmine tests for react-ga typscript library",
-            value: 4,
-            nonInteraction: true,
-        };
-
         ga.event(options);
+    });
+    it("Able to make event calls with multiple trackers", () => {
+        ga.initialize([
+            { trackingId: "abc", debug: true},
+            { trackingId: "efg", debug: true, gaOptions: { name: "blah" }}
+        ]);
+
+        ga.event(options, ["blah"]);
     });
 });
 
 describe("Testing react-ga set calls", () => {
+    const fieldObject: ga.FieldsObject = {
+        page: "/users"
+    };
+
     it("Able to make set calls", () => {
         ga.initialize("UA-65432-1");
 
-        const fieldObject: ga.FieldsObject = {
-            page: '/users'
-        };
-
         ga.set(fieldObject);
+    });
+    it("Able to make set calls with multiple trackers", () => {
+        ga.initialize([
+            { trackingId: "abc", debug: true},
+            { trackingId: "efg", debug: true, gaOptions: { name: "blah" }}
+        ]);
+
+        ga.set(fieldObject, ["blah"]);
     });
 });
 
@@ -65,35 +108,35 @@ describe("Testing react-ga v2.1.2", () => {
     });
     it("Able to make send calls", () => {
         let fieldObject: ga.FieldsObject = {
-            page: '/users'
+            page: "/users"
         };
 
-        ga.send(fieldObject);
+        ga.send(fieldObject, []);
     });
     it("Able to make timing calls", () => {
         ga.timing({
-            category: 'string',
-            variable: 'string',
+            category: "string",
+            variable: "string",
             value: 1,
-            label: 'string'
-        });
+            label: "string"
+        }, []);
     });
     it("Able to make exception calls", () => {
         let fieldObject: ga.FieldsObject = {
-            page: '/users'
+            page: "/users"
         };
-        ga.exception(fieldObject);
+        ga.exception(fieldObject, []);
     });
     it("Able to make plugin object calls", () => {
         const execute = ga.plugin.execute;
         const require = ga.plugin.require;
         const payload = {};
 
-        execute('name', 'action', payload);
-        execute('name', 'action', 'type', payload);
-        require('name', {});
+        execute("name", "action", payload);
+        execute("name", "action", "type", payload);
+        require("name", {});
     });
     it("Able to make outboundLink calls", () => {
-        ga.outboundLink({label: 'string'}, () => {});
+        ga.outboundLink({label: "string"}, () => {}, []);
     });
 });

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "jsx": "react",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-ga-tests.ts"
+    ]
+}


### PR DESCRIPTION
Closes #237 

To test TypeScript: `tsc types/react-ga-tests.ts`