### PR TITLE
Change the 'react' import the entire module rather than a default statement

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,7 +5,7 @@
 //                 Jerry Reptak <https://github.com/jetfault>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import React from 'react';
+import * as React from 'react';
 
 /* tslint:disable no-any */
 


### PR DESCRIPTION
Fixes #246 

The new React import statement is not compatible with @types/react and doesn't follow the standard format that is normally used when working with this library.

Changed to 
`import * as React from 'react';`
