### PR TITLE
Update Typescript definitions for multiple tracker support

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,6 +40,7 @@ export interface InitializeOptions {
     testMode?: boolean;
     titleCase?: boolean;
     gaOptions?: GaOptions;
+    alwaysSendToDefaultTracker?: boolean;
 }
 
 export type Tracker = {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -81,7 +81,7 @@ export interface OutboundLinkProps {
 }
 
 export function initialize(trackingCode: string, options?: InitializeOptions): void;
-export function initialize(trackers: Tracker[]): void;
+export function initialize(trackers: Tracker[], options?: InitializeOptions): void;
 export function ga(): any;
 export function set(fieldsObject: FieldsObject, trackerNames?: TrackerNames): void;
 export function send(fieldsObject: FieldsObject, trackerNames?: TrackerNames): void;


### PR DESCRIPTION
1. Add InitializeOptions to the multiple trackers initialize call 
2. Add the alwaysSendToDefaultTracker option to InitializeOptions