### PR TITLE
fixed the issue with ga script load if it is loaded by test framework

### DIFF
--- a/src/utils/loadGA.js
+++ b/src/utils/loadGA.js
@@ -10,7 +10,14 @@ export default function (options) {
       m = s.getElementsByTagName(o)[0];
     a.async = 1;
     a.src = g;
-    m.parentNode.insertBefore(a, m);
+    /**
+     * Check if there is no script tag found(possible with test framework such as Jest) then add the GA script to root element
+     */
+    if (m) {
+      m.parentNode.insertBefore(a, m);
+    } else {
+      s.documentElement.appendChild(a);
+    }
 })(window, document, 'script', options && options.gaAddress ? options.gaAddress : 'https://www.google-analytics.com/analytics.js', 'ga');
   /* eslint-enable */
 }


### PR DESCRIPTION
While using the google analytics code with test framework jest, there is possibility that there need not to be any other 'script' tag on the document. hence following line will return the value of 'm' as undefined.
https://github.com/react-ga/react-ga/blob/master/src/utils/loadGA.js#L10

This will break the GA load.

In general also it is always safe to check for the value before accessing object and it is not always safe to relay on the logic that expect at least one script tag to be there on the page.