### PR TITLE
Check for window before accessing window.ga on import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ let _alwaysSendToDefaultTracker = true;
 
 const internalGa = (...args) => {
   if (_testMode) return TestModeAPI.ga(...args);
+  if (typeof window === 'undefined') return false;
   if (!window.ga) return warn('ReactGA.initialize must be called first or GoogleAnalytics should be loaded manually');
   return window.ga(...args);
 };


### PR DESCRIPTION
Check for `window` before accessing `window.ga`. This gets invoked as soon as ReactGA is imported, thus can't be avoided without using conditional `require` which can be messy.

The following code does not currently work, but will be possible after this PR:

```js
import ReactGA from 'react-ga';

// Don't initialize during static build / server-side render.
if (typeof window !== 'undefined') {
  ReactGA.initialize('ID');
}
```

Resolves https://github.com/react-ga/react-ga/issues/98
Resolves https://github.com/react-ga/react-ga/issues/272