### PR TITLE
Removed "to" attribute on OutboundLink.

### DIFF
--- a/src/components/OutboundLink.js
+++ b/src/components/OutboundLink.js
@@ -50,7 +50,10 @@ export default class OutboundLink extends Component {
       href: this.props.to,
       onClick: this.handleClick
     };
+
+    delete props.to;
     delete props.eventLabel;
+
     return React.createElement('a', props);
   }
 }


### PR DESCRIPTION
As far as I can tell, the `to` attribute is unnecessary and should be removed before element is
created, so that it does not appear in the DOM (much like the `eventLabel` attribute).