### PR TITLE
Add documentation for multiple trackers on `set` and `pageview`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,16 @@ This will help you figure out if your implementation is off or your GA Settings 
 ReactGA.set({ userId: 123 });
 ```
 
+Or with multiple trackers
+
+```js
+ReactGA.set({ userId: 123 }, ['tracker2']);
+```
+
 |Value|Notes|
 |------|-----|
 |fieldsObject|`Object`. e.g. `{ userId: 123 }`|
+|trackerNames|`Array`. Optional. A list of extra trackers to run the command on|
 
 #### ReactGA.pageview(path)
 
@@ -136,6 +143,13 @@ ReactGA.set({ userId: 123 });
 ```js
 ReactGA.pageview('/about/contact-us');
 ```
+
+Or with multiple trackers
+
+```js
+ReactGA.pageview('/about/contact-us', ['tracker2']);
+```
+This will send all the named trackers listed in the array parameter. The default tracker will or will not send according to the `initialize()` setting `alwaysSendToDefaultTracker` (defaults to `true` if not provided).
 
 |Value|Notes|
 |------|-----|


### PR DESCRIPTION
I spent more time than I'd like yesterday struggling with multiple trackers because the documentation did not give enough information. Only by sifting through issues and unit test code did I find what I needed.

To help out other users interested in using multiple trackers, I added "or with multiple trackers" documentation to the README.