### PR TITLE
Types: OutboundLink takes Anchor Props

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -94,4 +94,4 @@ export function exception(fieldsObject: FieldsObject, trackerNames?: TrackerName
 export const plugin: Plugin;
 export const testModeAPI: TestModeAPI;
 export function outboundLink(args: OutboundLinkArgs, hitCallback: () => void, trackerNames?: TrackerNames): void;
-export const OutboundLink : React.ComponentClass<OutboundLinkProps & React.HTMLProps<OutboundLinkProps>>;
+export const OutboundLink : React.ComponentClass<OutboundLinkProps & React.HTMLProps<HTMLAnchorElement>>;


### PR DESCRIPTION
lets you pass `rel` and other Anchor Props