### PR TITLE
Change umd build globalObject. Possible fix for #313

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,8 @@ module.exports = {
   output: {
     path: path.resolve('./dist'),
     filename: '[name].js',
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: 'typeof self !== \'undefined\' ? self : this' // temporary fix for https://github.com/webpack/webpack/issues/6525
   },
   externals: []
     .concat(Object.keys(pkg.peerDependencies))


### PR DESCRIPTION
This could fix #313 which is probably caused by https://github.com/webpack/webpack/issues/6525.

However, I have no way to test this in server side rendering, I only tested that it still works in browser environment.

But it's probably fixed as now react-ga can be imported on node:
```
> require('react-ga')
Object [Module] {
  initialize: [Getter],
  ga: [Getter],

```

before this PR:
```
> require('react-ga')
ReferenceError: window is not defined
```