### PR TITLE
Build umd with commonjs modules. Fixes jest.mock()

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,9 @@
   "presets": [["@babel/env", { "modules": false }], "@babel/react"],
   "plugins": ["@babel/plugin-proposal-class-properties"],
   "env": {
+    "umd": {
+      "presets": [["@babel/env", { "modules": "commonjs" }]],
+    },
     "test": {
       "presets": [["@babel/env", { "modules": "commonjs" }]],
       "plugins": ["istanbul", "rewire"]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test-only": "BABEL_ENV=test nyc mocha",
     "build": "npm run build:umd && npm run build:esm",
     "build:esm": "BABEL_ENV=esm babel src --out-dir dist/esm",
-    "build:umd": "webpack --mode=production",
+    "build:umd": "BABEL_ENV=umd webpack --mode=production",
     "lint": "eslint src webpack.config.js test --ext .js,.jsx",
     "preversion": "npm test && npm run lint",
     "version": "node ./version-bower.js && npm run build && git add -A dist bower.json",


### PR DESCRIPTION
This fixes #316 jest mocking problem.

I really don't know why it fixes it though. UMD bundle size goes up by 2kB.