### PR TITLE
add args of type any to ga type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -83,7 +83,7 @@ export interface OutboundLinkProps {
 
 export function initialize(trackingCode: string, options?: InitializeOptions): void;
 export function initialize(trackers: Tracker[], options?: InitializeOptions): void;
-export function ga(): any;
+export function ga(args: any): void;
 export function set(fieldsObject: FieldsObject, trackerNames?: TrackerNames): void;
 export function send(fieldsObject: FieldsObject, trackerNames?: TrackerNames): void;
 export function pageview(path: string, trackerNames?: TrackerNames, title?: string): void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -83,7 +83,7 @@ export interface OutboundLinkProps {
 
 export function initialize(trackingCode: string, options?: InitializeOptions): void;
 export function initialize(trackers: Tracker[], options?: InitializeOptions): void;
-export function ga(args: any): void;
+export function ga(...args: any): void;
 export function set(fieldsObject: FieldsObject, trackerNames?: TrackerNames): void;
 export function send(fieldsObject: FieldsObject, trackerNames?: TrackerNames): void;
 export function pageview(path: string, trackerNames?: TrackerNames, title?: string): void;


### PR DESCRIPTION
Fix #325

Improves the type definition for the ga() method by allowing it to correctly accept arguments.