### PR TITLE
Add standardImplementation option to types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -41,6 +41,7 @@ export interface InitializeOptions {
     titleCase?: boolean;
     gaOptions?: GaOptions;
     alwaysSendToDefaultTracker?: boolean;
+    standardImplementation?: boolean;
 }
 
 export type Tracker = {


### PR DESCRIPTION
This PR adds `standardImplementation` to `InitializeOptions` interface.