### PR TITLE
Return callable from `ga()` without args

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,7 +86,8 @@ export interface OutboundLinkProps {
 
 export function initialize(trackingCode: string, options?: InitializeOptions): void;
 export function initialize(trackers: Tracker[], options?: InitializeOptions): void;
-export function ga(...args: any[]) : any;
+export function ga(): (...args: any[]) => void;
+export function ga(...args: any[]): void;
 export function resetCalls() : void;
 export function set(fieldsObject: FieldsObject, trackerNames?: TrackerNames): void;
 export function send(fieldsObject: FieldsObject, trackerNames?: TrackerNames): void;


### PR DESCRIPTION
As documented on "Usage without arguments" in [ReactGA.ga()](https://github.com/react-ga/react-ga#reactgaga), based on #342.