### PR TITLE
ga should return window.ga

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -84,7 +84,7 @@ export interface OutboundLinkProps {
 
 export function initialize(trackingCode: string, options?: InitializeOptions): void;
 export function initialize(trackers: Tracker[], options?: InitializeOptions): void;
-export function ga(...args: any): void;
+export function ga(...args: any): any;
 export function resetCalls() : void;
 export function set(fieldsObject: FieldsObject, trackerNames?: TrackerNames): void;
 export function send(fieldsObject: FieldsObject, trackerNames?: TrackerNames): void;


### PR DESCRIPTION
It would appear that the `ga` function should not be listed to return `void` as it should return `window.ga`

https://github.com/react-ga/react-ga/blob/master/src/index.js#L107-L121