### PR TITLE
Remove error caused by v2.6.0 trackerNames being added as HTML attribute for SSR

### DIFF
--- a/src/components/OutboundLink.js
+++ b/src/components/OutboundLink.js
@@ -59,6 +59,7 @@ export default class OutboundLink extends Component {
     }
 
     delete props.eventLabel;
+    delete props.trackerNames;
     return React.createElement('a', props);
   }
 }


### PR DESCRIPTION
If non valid HTML attributes are added React will not omit them. The explanation can be viewed [here](https://gist.github.com/jimfb/d99e0678e9da715ccf6454961ef04d1b#gistcomment-1819019) with Dan Abramov.

This seems to be only happening with version 2.6.0 and works fine with version 2.5.7. I had to revert back for project I work on [here](https://github.com/OperationCode/front-end/pull/626).

Sandbox recreating the issue with Next.js: https://codesandbox.io/s/hello-world-k1nsf (see console log)

My solution was just to remove the attribute, like what's currently done with `eventLabel`.

IMO it would be better solution to remove both `eventLabel` and `trackerNames` by destructuring on line#50. Which is less LoC and readability stays the same.

![Screenshot (2)](https://user-images.githubusercontent.com/2691129/59981450-6bc09f00-95d1-11e9-9d44-2d730ee52968.png)
