### PR TITLE
Remove warning when using OutboundLinnk

### DIFF
--- a/src/components/OutboundLink.js
+++ b/src/components/OutboundLink.js
@@ -59,6 +59,7 @@ export default class OutboundLink extends Component {
     }
 
     delete props.eventLabel;
+    delete props.trackerNames;
     return React.createElement('a', props);
   }
 }


### PR DESCRIPTION
React throw a warning when using an OutboundLink because the props trackerNames is spread to the a component that don't use it

```
Warning: React does not recognize the `trackerNames` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `trackernames` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```