### PR TITLE
Remove trackerNames before passing to a element

### DIFF
--- a/src/components/OutboundLink.js
+++ b/src/components/OutboundLink.js
@@ -59,6 +59,7 @@ export default class OutboundLink extends Component {
     }
 
     delete props.eventLabel;
+    delete props.trackerNames;
     return React.createElement('a', props);
   }
 }


### PR DESCRIPTION
Remove `trackerNames` before adding it to `a` element. Fixes #376 