### PR TITLE
Adding initialization logic to enable use of existing `window.ga`

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ ReactGA.initialize([{
 |options.alwaysSendToDefaultTracker| `Boolean`. Optional. Defaults to `true`. If set to `false` _and_ using multiple trackers, the event will not be send to the default tracker.|
 |options.testMode| `Boolean`. Optional. Defaults to `false`. Enables test mode. See [here](https://github.com/react-ga/react-ga#test-mode) for more information.|
 |options.standardImplementation| `Boolean`. Optional. Defaults to `false`. Enables loading GA as google expects it. See [here](https://github.com/react-ga/react-ga#standard-implementation) for more information.|
+|options.useExistingGa| `Boolean`. Optional. Skips call to `window.ga()`, assuming you have manually run it.
 
 If you are having additional troubles and setting `debug = true` shows as working please try using the [Chrome GA Debugger Extension](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna).
 This will help you figure out if your implementation is off or your GA Settings are not correct.

--- a/src/core.js
+++ b/src/core.js
@@ -67,6 +67,10 @@ function _initialize(gaTrackingID, options) {
     if (options.titleCase === false) {
       _titleCase = false;
     }
+
+    if (options.useExistingGa) {
+      return;
+    }
   }
 
   if (options && options.gaOptions) {

--- a/test/functionality/initialize.js
+++ b/test/functionality/initialize.js
@@ -7,7 +7,7 @@ export default function initializeTests(spies) {
       (typeof window.ga).should.eql('function');
     });
 
-    it('should call window.ga()', function () {
+    it('should call window.ga() if no options given', function () {
       ReactGA.initialize('foo');
       spies.ga.args.should.eql([
         ['create', 'foo', 'auto']
@@ -19,6 +19,11 @@ export default function initializeTests(spies) {
       spies.ga.args.should.eql([
         ['create', 'foo', { userId: 123 }]
       ]);
+    });
+
+    it('should not call window.ga() if options.useExistingGa is set', function () {
+      ReactGA.initialize('foo', { useExistingGa: true });
+      spies.ga.callCount.should.eql(0);
     });
 
     it('should initialize multiple trackers if they are given', function () {


### PR DESCRIPTION
This PR is to allow usage of an existing `window.ga` function. Adds support for lazy loading modules that want to use ReactGA when the host environment already bootstrapped the tracker.