### PR TITLE
Improve performance of mightBeEmail check

### DIFF
--- a/src/utils/mightBeEmail.js
+++ b/src/utils/mightBeEmail.js
@@ -2,5 +2,5 @@
 // https://support.google.com/analytics/answer/2795983?hl=en
 export default function mightBeEmail(s) {
   // There's no point trying to validate rfc822 fully, just look for ...@...
-  return (/[^@]+@[^@]+/).test(s);
+  return typeof s === 'string' && s.indexOf('@') !== -1;
 }


### PR DESCRIPTION
While sending in a large amount of data (containing a large amount of zip codes), we observed that our app was slowing down significantly (on the order of seconds). This regex turned out to be the culprit.

Since we only seem to care about about the presence of the “@” character, this should speed things up.

**Benchmark:** https://jsperf.com/fast-email-test/1