### PR TITLE
Support to require plugin with specific tracker when multiple trackers are used

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -409,7 +409,6 @@ export const plugin = {
    * @param name {String} e.g. 'ecommerce' or 'myplugin'
    * @param options {Object} optional e.g {path: '/log', debug: true}
    * @param trackerName {String} optional e.g 'trackerName'
-   *  
    */
   require: (rawName, options, trackerName) => {
     if (typeof ga === 'function') {
@@ -424,7 +423,7 @@ export const plugin = {
         warn('`name` cannot be an empty string in .require()');
         return;
       }
-      let requireString = trackerName ? trackerName + '.require' : 'require'
+      const requireString = trackerName ? `${trackerName}.require` : 'require';
       // Optional Fields
       if (options) {
         if (typeof options !== 'object') {

--- a/src/core.js
+++ b/src/core.js
@@ -405,7 +405,7 @@ export const plugin = {
    * @param name {String} e.g. 'ecommerce' or 'myplugin'
    * @param options {Object} optional e.g {path: '/log', debug: true}
    */
-  require: (rawName, options) => {
+  require: (rawName, options, trackerName) => {
     if (typeof ga === 'function') {
       // Required Fields
       if (!rawName) {
@@ -418,7 +418,7 @@ export const plugin = {
         warn('`name` cannot be an empty string in .require()');
         return;
       }
-
+      let requireString = trackerName ? trackerName + '.require' : 'require'
       // Optional Fields
       if (options) {
         if (typeof options !== 'object') {
@@ -430,13 +430,13 @@ export const plugin = {
           warn('Empty `options` given to .require()');
         }
 
-        ga('require', name, options);
+        ga(requireString, name, options);
 
         if (_debug) {
           log(`called ga('require', '${name}', ${JSON.stringify(options)}`);
         }
       } else {
-        ga('require', name);
+        ga(requireString, name);
 
         if (_debug) {
           log(`called ga('require', '${name}');`);

--- a/src/core.js
+++ b/src/core.js
@@ -405,7 +405,7 @@ export const plugin = {
    * @param name {String} e.g. 'ecommerce' or 'myplugin'
    * @param options {Object} optional e.g {path: '/log', debug: true}
    */
-  require: (rawName, options, trackerName) => {
+  require: (rawName, options) => {
     if (typeof ga === 'function') {
       // Required Fields
       if (!rawName) {
@@ -418,7 +418,7 @@ export const plugin = {
         warn('`name` cannot be an empty string in .require()');
         return;
       }
-      let requireString = trackerName ? trackerName + '.require' : 'require'
+
       // Optional Fields
       if (options) {
         if (typeof options !== 'object') {
@@ -430,13 +430,13 @@ export const plugin = {
           warn('Empty `options` given to .require()');
         }
 
-        ga(requireString, name, options);
+        ga('require', name, options);
 
         if (_debug) {
           log(`called ga('require', '${name}', ${JSON.stringify(options)}`);
         }
       } else {
-        ga(requireString, name);
+        ga('require', name);
 
         if (_debug) {
           log(`called ga('require', '${name}');`);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -62,14 +62,14 @@ export interface TimingArgs {
 }
 
 export interface Plugin {
-    require(name: string, options?: any, trackerName?: string): void;
-    execute(pluginName: string, action: string, actionTypeOrPayload: string | any, payload?: any): void;
+    require(name: string, options?: any): void;
+    execute(pluginName: string, action: string, actionTypeOrPayload: string|any, payload?: any): void;
 }
 
 export interface TestModeAPI {
-    calls: any[][];
-    ga: (...args: any[]) => any;
-    resetCalls: Function;
+  calls: any[][];
+  ga: (...args: any[]) => any;
+  resetCalls: Function;
 }
 
 export interface OutboundLinkArgs {
@@ -86,8 +86,8 @@ export interface OutboundLinkProps {
 
 export function initialize(trackingCode: string, options?: InitializeOptions): void;
 export function initialize(trackers: Tracker[], options?: InitializeOptions): void;
-export function ga(...args: any[]): any;
-export function resetCalls(): void;
+export function ga(...args: any[]) : any;
+export function resetCalls() : void;
 export function set(fieldsObject: FieldsObject, trackerNames?: TrackerNames): void;
 export function send(fieldsObject: FieldsObject, trackerNames?: TrackerNames): void;
 export function pageview(path: string, trackerNames?: TrackerNames, title?: string): void;
@@ -98,4 +98,4 @@ export function exception(fieldsObject: FieldsObject, trackerNames?: TrackerName
 export const plugin: Plugin;
 export const testModeAPI: TestModeAPI;
 export function outboundLink(args: OutboundLinkArgs, hitCallback: () => void, trackerNames?: TrackerNames): void;
-export const OutboundLink: React.ComponentClass<OutboundLinkProps & React.HTMLProps<HTMLAnchorElement>>;
+export const OutboundLink : React.ComponentClass<OutboundLinkProps & React.HTMLProps<HTMLAnchorElement>>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -62,14 +62,14 @@ export interface TimingArgs {
 }
 
 export interface Plugin {
-    require(name: string, options?: any): void;
-    execute(pluginName: string, action: string, actionTypeOrPayload: string|any, payload?: any): void;
+    require(name: string, options?: any, trackerName?: string): void;
+    execute(pluginName: string, action: string, actionTypeOrPayload: string | any, payload?: any): void;
 }
 
 export interface TestModeAPI {
-  calls: any[][];
-  ga: (...args: any[]) => any;
-  resetCalls: Function;
+    calls: any[][];
+    ga: (...args: any[]) => any;
+    resetCalls: Function;
 }
 
 export interface OutboundLinkArgs {
@@ -86,8 +86,8 @@ export interface OutboundLinkProps {
 
 export function initialize(trackingCode: string, options?: InitializeOptions): void;
 export function initialize(trackers: Tracker[], options?: InitializeOptions): void;
-export function ga(...args: any[]) : any;
-export function resetCalls() : void;
+export function ga(...args: any[]): any;
+export function resetCalls(): void;
 export function set(fieldsObject: FieldsObject, trackerNames?: TrackerNames): void;
 export function send(fieldsObject: FieldsObject, trackerNames?: TrackerNames): void;
 export function pageview(path: string, trackerNames?: TrackerNames, title?: string): void;
@@ -98,4 +98,4 @@ export function exception(fieldsObject: FieldsObject, trackerNames?: TrackerName
 export const plugin: Plugin;
 export const testModeAPI: TestModeAPI;
 export function outboundLink(args: OutboundLinkArgs, hitCallback: () => void, trackerNames?: TrackerNames): void;
-export const OutboundLink : React.ComponentClass<OutboundLinkProps & React.HTMLProps<HTMLAnchorElement>>;
+export const OutboundLink: React.ComponentClass<OutboundLinkProps & React.HTMLProps<HTMLAnchorElement>>;

--- a/types/react-ga-tests.ts
+++ b/types/react-ga-tests.ts
@@ -134,7 +134,7 @@ describe("Testing react-ga v2.1.2", () => {
 
         execute("name", "action", payload);
         execute("name", "action", "type", payload);
-        require("name", {});
+        require("name", {}, 'trackerName');
     });
     it("Able to make outboundLink calls", () => {
         ga.outboundLink({label: "string"}, () => {}, []);

--- a/types/react-ga-tests.ts
+++ b/types/react-ga-tests.ts
@@ -134,7 +134,7 @@ describe("Testing react-ga v2.1.2", () => {
 
         execute("name", "action", payload);
         execute("name", "action", "type", payload);
-        require("name", {}, 'trackerName');
+        require("name", {});
     });
     it("Able to make outboundLink calls", () => {
         ga.outboundLink({label: "string"}, () => {}, []);


### PR DESCRIPTION
When multiple trackers are being used, both having distinct tracker name, then ecommerce plugin doesn't initialise. In this pull request I have added Support to require plugin with specific tracker when multiple trackers are used.