### PR TITLE
Expose addTrackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,33 @@ ReactGA.initialize([{
 If you are having additional troubles and setting `debug = true` shows as working please try using the [Chrome GA Debugger Extension](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna).
 This will help you figure out if your implementation is off or your GA Settings are not correct.
 
+#### ReactGA.initialize(gaTrackingID, options)
+
+GA must be initialized before using this function. The values are checked and sent through to the `ga('create', ...` call.
+
+###### Example
+
+```js
+ReactGA.initialize('UA-000000-01', {
+  debug: true,
+  titleCase: false,
+  gaOptions: {
+    userId: 123
+  }
+});
+
+ReactGA.addTrackers([{
+  trackingId: 'UA-000000-01',
+  gaOptions: {
+    name: 'tracker1',
+    userId: 123
+  }
+}, {
+ trackingId: 'UA-000000-02',
+ gaOptions: { name: 'tracker2' }
+}], { debug: true, alwaysSendToDefaultTracker: false });
+```
+
 #### ReactGA.set(fieldsObject)
 
 This will set the values of [custom dimensions](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#dimension) in Google Analytics.

--- a/src/core.js
+++ b/src/core.js
@@ -110,10 +110,7 @@ export function initialize(configsOrTrackingId, options) {
     options.alwaysSendToDefaultTracker : true;
 
   addTrackers(configsOrTrackingId);
-  
 }
-
-
 
 /**
  * ga:

--- a/src/core.js
+++ b/src/core.js
@@ -80,6 +80,20 @@ function _initialize(gaTrackingID, options) {
   }
 }
 
+export function addTrackers(configsOrTrackingId) {
+  if (Array.isArray(configsOrTrackingId)) {
+    configsOrTrackingId.forEach((config) => {
+      if (typeof config !== 'object') {
+        warn('All configs must be an object');
+        return;
+      }
+      _initialize(config.trackingId, config);
+    });
+  } else {
+    _initialize(configsOrTrackingId, options);
+  }
+  return true;
+} 
 
 export function initialize(configsOrTrackingId, options) {
   if (options && options.testMode === true) {
@@ -95,19 +109,11 @@ export function initialize(configsOrTrackingId, options) {
   _alwaysSendToDefaultTracker = (options && typeof options.alwaysSendToDefaultTracker === 'boolean') ?
     options.alwaysSendToDefaultTracker : true;
 
-  if (Array.isArray(configsOrTrackingId)) {
-    configsOrTrackingId.forEach((config) => {
-      if (typeof config !== 'object') {
-        warn('All configs must be an object');
-        return;
-      }
-      _initialize(config.trackingId, config);
-    });
-  } else {
-    _initialize(configsOrTrackingId, options);
-  }
-  return true;
+  addTrackers(configsOrTrackingId);
+  
 }
+
+
 
 /**
  * ga:

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-import UnboundOutboundLink from "./components/OutboundLink";
-import * as Defaults from "./core";
+import UnboundOutboundLink from './components/OutboundLink';
+import * as Defaults from './core';
 
 export const initialize = Defaults.initialize;
 export const addTrackers = Defaults.addTrackers;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
-import UnboundOutboundLink from './components/OutboundLink';
-import * as Defaults from './core';
+import UnboundOutboundLink from "./components/OutboundLink";
+import * as Defaults from "./core";
 
 export const initialize = Defaults.initialize;
+export const addTrackers = Defaults.addTrackers;
 export const ga = Defaults.ga;
 export const set = Defaults.set;
 export const send = Defaults.send;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -88,6 +88,8 @@ export interface OutboundLinkProps {
 
 export function initialize(trackingCode: string, options?: InitializeOptions): void;
 export function initialize(trackers: Tracker[], options?: InitializeOptions): void;
+export function addTrackers(trackingCode: string): void;
+export function addTrackers(trackers: Tracker[]): void;
 export function ga(): (...args: any[]) => void;
 export function ga(...args: any[]): void;
 export function resetCalls() : void;


### PR DESCRIPTION
### The situation
I read some issues where people are confused with the initialization of multiple trackers. Forcing many initializations.

In some cases like mine, there is the need or initialized and add later some trackers.
For example, I have an internal tracker that is needed since the loading process. In addition, I have some custom customer trackers that will be available after a few logic and a fetch.

### A possible solution
Extract the `addTracker` logic to an independent function and expose it.