### PR TITLE
Support for cookie flags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6361,9 +6361,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
-      "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -8494,7 +8494,6 @@
         "align-text": {
           "version": "0.1.4",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
@@ -8504,8 +8503,7 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "ansi-regex": {
           "version": "3.0.0",
@@ -8532,8 +8530,7 @@
         },
         "async": {
           "version": "1.5.2",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "balanced-match": {
           "version": "1.0.0",
@@ -8568,13 +8565,11 @@
         "camelcase": {
           "version": "1.2.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "align-text": "^0.1.3",
@@ -8584,7 +8579,6 @@
         "cliui": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "center-align": "^0.1.1",
@@ -8595,7 +8589,6 @@
             "wordwrap": {
               "version": "0.0.2",
               "bundled": true,
-              "dev": true,
               "optional": true
             }
           }
@@ -8647,8 +8640,7 @@
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "default-require-extensions": {
           "version": "2.0.0",
@@ -8757,27 +8749,6 @@
           "bundled": true,
           "dev": true
         },
-        "handlebars": {
-          "version": "4.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "async": "^1.4.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.4.4",
-            "uglify-js": "^2.6"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.4.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
-            }
-          }
-        },
         "has-flag": {
           "version": "3.0.0",
           "bundled": true,
@@ -8820,7 +8791,6 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "is-builtin-module": {
@@ -8904,7 +8874,6 @@
         "kind-of": {
           "version": "3.2.2",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
@@ -8913,7 +8882,6 @@
         "lazy-cache": {
           "version": "1.0.4",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "lcid": {
@@ -8952,7 +8920,6 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "lru-cache": {
@@ -9023,8 +8990,7 @@
         },
         "minimist": {
           "version": "0.0.10",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "mkdirp": {
           "version": "0.5.1",
@@ -9081,7 +9047,6 @@
         "optimist": {
           "version": "0.6.1",
           "bundled": true,
-          "dev": true,
           "requires": {
             "minimist": "~0.0.1",
             "wordwrap": "~0.0.2"
@@ -9219,7 +9184,6 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "require-directory": {
@@ -9240,7 +9204,6 @@
         "right-align": {
           "version": "0.1.3",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "align-text": "^0.1.1"
@@ -9290,7 +9253,6 @@
         "source-map": {
           "version": "0.5.7",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "spawn-wrap": {
@@ -9383,8 +9345,6 @@
         "uglify-js": {
           "version": "2.8.29",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "source-map": "~0.5.1",
             "uglify-to-browserify": "~1.0.0",
@@ -9394,7 +9354,6 @@
             "yargs": {
               "version": "3.10.0",
               "bundled": true,
-              "dev": true,
               "optional": true,
               "requires": {
                 "camelcase": "^1.0.2",
@@ -9408,7 +9367,6 @@
         "uglify-to-browserify": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "uuid": {
@@ -9441,13 +9399,11 @@
         "window-size": {
           "version": "0.1.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "bundled": true,
-          "dev": true
+          "bundled": true
         },
         "wrap-ansi": {
           "version": "2.1.0",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -34,6 +34,7 @@ export interface GaOptions {
     userId?: string;
     storage?: string;
     storeGac?: boolean;
+    cookieFlags?: string;
 }
 
 export interface InitializeOptions {


### PR DESCRIPTION
Add support for cookieFlags option in GaOptions, this is mainly for applications which are embeddable. It can be set like this 
```
 initialize(gaID, {
    debug,
    gaOptions: { cookieFlags: 'max-age=7200;secure;samesite=none' },
  })
```