### PR TITLE
fix(timing): skip warning for falsy value

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -272,7 +272,7 @@ export function timing(
   trackerNames
 ) {
   if (typeof ga === 'function') {
-    if (!category || !variable || !value || typeof value !== 'number') {
+    if (!category || !variable || typeof value !== 'number') {
       warn(
         'args.category, args.variable ' +
           'AND args.value are required in timing() ' +

--- a/test/functionality/timing.test.js
+++ b/test/functionality/timing.test.js
@@ -79,6 +79,20 @@ describe('timing()', () => {
     );
   });
 
+  it('should not warn if value arg is 0, a falsy number', () => {
+    ReactGA.initialize('foo');
+    ReactGA.timing({
+      category: 'Test',
+      variable: 'Timing test',
+      value: 0
+    });
+    expect(spies.warn).not.toHaveBeenCalledWith(
+      '[react-ga]',
+      'args.category, args.variable AND args.value are required in timing() ' +
+        'AND args.value has to be a number'
+    );
+  });
+
   it('should warn if value arg is not a number', () => {
     ReactGA.initialize('foo');
     ReactGA.timing({


### PR DESCRIPTION
Per [issue 123](https://github.com/react-ga/react-ga/issues/123), falsy values are triggering warning. This skips the test for non-falsy values, along with an automated test.

[Previous fix](https://github.com/react-ga/react-ga/pull/124/commits/ec433af90ee9d73d5bdf177f777caf3572788c68) appears to be not in "any branch in this repo".