### PR TITLE
Feature: Allow onerror callback in loadGA

### DIFF
--- a/src/utils/loadGA.js
+++ b/src/utils/loadGA.js
@@ -6,6 +6,8 @@ export default function (options) {
     gaAddress = 'https://www.google-analytics.com/analytics_debug.js';
   }
 
+  const onerror = options && options.onerror;
+
   // https://developers.google.com/analytics/devguides/collection/analyticsjs/
   /* eslint-disable */
   (function (i, s, o, g, r, a, m) {
@@ -19,6 +21,7 @@ export default function (options) {
     (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
     a.async = 1;
     a.src = g;
+    a.onerror = onerror;
     m.parentNode.insertBefore(a, m);
   })(window, document, 'script', gaAddress, 'ga');
   /* eslint-enable */


### PR DESCRIPTION
Allow callers to set an `onerror` callback on the script tag for Google Analytics. Some ad blockers cause Google Analytics to fail to load so this would allow callers to handle that error.

Example usage to log GA failures in Sentry:

```js
const onerror = function onerror(/* event */) {
  Sentry.captureException(new Error('Failed to load Google Analytics Script'));
}

initGA({ onerror });
```