### PR TITLE
Fix trim for integer value

### DIFF
--- a/src/utils/trim.js
+++ b/src/utils/trim.js
@@ -2,5 +2,5 @@
 // browsers have String.prototoype.trim().
 
 export default function trim(s) {
-  return s && s.replace(/^\s+|\s+$/g, '');
+    return s && s.toString().replace(/^\s+|\s+$/g, '');
 }


### PR DESCRIPTION
On giving any non-string value to any of the parameter of ReactGA.event we are getting error r.replace is not a function. So I found out it is only valid for strings so to trim the data in trim.js add s.toString().replace so we will get no error.