### PR TITLE
fix: add cookieUpdate to GaOptions interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -48,6 +48,7 @@ export interface GaOptions {
   cookieName?: string;
   cookieDomain?: string;
   cookieExpires?: number;
+  cookieUpdate?: boolean;
   legacyCookieDomain?: string;
   legacyHistoryImport?: boolean;
   allowLinker?: boolean;


### PR DESCRIPTION
`cookieUpdate` was missing in the interface.

See https://developers.google.com/analytics/devguides/collection/analyticsjs/cookies-user-id for more info.