### PR TITLE
Feature: Type hinting and tests for dimensions/metrics

### DIFF
--- a/test/functionality/event.test.js
+++ b/test/functionality/event.test.js
@@ -145,7 +145,7 @@ describe('event()', () => {
     });
   });
 
-  it('should record a value value', () => {
+  it('should record a value', () => {
     ReactGA.initialize('foo');
     ReactGA.event({ category: 'Test', action: 'Send Test', value: 10 });
     expect(spies.ga).toHaveBeenCalledTimes(2);
@@ -158,7 +158,7 @@ describe('event()', () => {
     });
   });
 
-  it('should record a value value of zero', () => {
+  it('should record a value of zero', () => {
     ReactGA.initialize('foo');
     ReactGA.event({ category: 'Test', action: 'Send Test', value: 0 });
     expect(spies.ga).toHaveBeenCalledTimes(2);

--- a/test/functionality/event.test.js
+++ b/test/functionality/event.test.js
@@ -282,4 +282,40 @@ describe('event()', () => {
       hitType: 'event'
     });
   });
+
+  it('should send custom dimensions with the event payload', () => {
+    ReactGA.initialize('foo');
+    ReactGA.event({
+      category: 'Test',
+      action: 'Send Test',
+      dimension1: 'foo',
+      dimension20: 'bar'
+    });
+
+    expect(spies.ga).toHaveBeenCalledWith('send', {
+      eventAction: 'Send Test',
+      eventCategory: 'Test',
+      hitType: 'event',
+      dimension1: 'foo',
+      dimension20: 'bar'
+    });
+  });
+
+  it('should send custom metrics with the event payload', () => {
+    ReactGA.initialize('foo');
+    ReactGA.event({
+      category: 'Test',
+      action: 'Send Test',
+      metric1: 1,
+      metric20: 2.6
+    });
+
+    expect(spies.ga).toHaveBeenCalledWith('send', {
+      eventAction: 'Send Test',
+      eventCategory: 'Test',
+      hitType: 'event',
+      metric1: 1,
+      metric20: 2.6
+    });
+  });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -36,6 +36,48 @@ export interface EventArgs {
    * depending on hit size.
    */
   transport?: 'beacon' | 'xhr' | 'image';
+  /** Custom dimensions */
+  dimension1?: string;
+  dimension2?: string;
+  dimension3?: string;
+  dimension4?: string;
+  dimension5?: string;
+  dimension6?: string;
+  dimension7?: string;
+  dimension8?: string;
+  dimension9?: string;
+  dimension10?: string;
+  dimension11?: string;
+  dimension12?: string;
+  dimension13?: string;
+  dimension14?: string;
+  dimension15?: string;
+  dimension16?: string;
+  dimension17?: string;
+  dimension18?: string;
+  dimension19?: string;
+  dimension20?: string;
+  /** Custom metrics */
+  metric1?: number;
+  metric2?: number;
+  metric3?: number;
+  metric4?: number;
+  metric5?: number;
+  metric6?: number;
+  metric7?: number;
+  metric8?: number;
+  metric9?: number;
+  metric10?: number;
+  metric11?: number;
+  metric12?: number;
+  metric13?: number;
+  metric14?: number;
+  metric15?: number;
+  metric16?: number;
+  metric17?: number;
+  metric18?: number;
+  metric19?: number;
+  metric20?: number;
 }
 
 export interface GaOptions {

--- a/types/react-ga-tests.ts
+++ b/types/react-ga-tests.ts
@@ -80,6 +80,27 @@ describe('Testing react-ga event calls', () => {
 
     ga.event(options, ['blah']);
   });
+
+  it('Able to pass custom dimensions with events', () => {
+    const payloadWithDimensions: ga.EventArgs = {
+      dimension1: 'foo',
+      dimension20: 'bar',
+      ...options
+    }
+    ga.initialize('UA-65432-1');
+
+    ga.event(payloadWithDimensions);
+  });
+
+  it('Able to pass custom metrics with events', () => {
+    const payloadWithmetrics: ga.EventArgs = {
+      metric1: 1,
+      metric20: 2.99,
+      ...options
+    }
+    ga.initialize('UA-65432-1');
+
+    ga.event(payloadWithmetrics);
 });
 
 describe('Testing react-ga set calls', () => {


### PR DESCRIPTION
Adding some types for dimensions and metrics. Helps code completion and removes the need to ignore ts warnings.

Currently we've been ignoring the ts warnings which this removes. Custom dimensions and metrics have a max of 20 for the normal Google Analytics. Analytics 360 has a limit of 200 for each, which I'm not sure this project supports.

```
        // @ts-ignore
        dimension2: params.keywords,
        // @ts-ignore
        dimension3: params.categories,
        // @ts-ignore
        dimension4: params.locations,
        // @ts-ignore
        dimension5: params.workTypes,
        // @ts-ignore
        dimension6: params.sectors,
        // @ts-ignore
```