### PR TITLE
feat: include custom rel props when target is blank

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6488,21 +6488,6 @@
       "integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==",
       "dev": true
     },
-    "execa": {
-      "version": "0.11.0",
-      "resolved": "https://verdaccio.tablesolution.com/execa/-/execa-0.11.0.tgz",
-      "integrity": "sha512-k5AR22vCt1DcfeiRixW46U5tMLtBg44ssdJM9PiXw3D8Bn5qyxFCSnKY/eR22y+ctFDGPqafpaXg2G4Emyua4A==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      }
-    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://verdaccio.tablesolution.com/exit/-/exit-0.1.2.tgz",

--- a/src/components/OutboundLink.js
+++ b/src/components/OutboundLink.js
@@ -50,7 +50,7 @@ export default class OutboundLink extends Component {
     };
 
     if (target === NEWTAB) {
-      props.rel = 'noopener noreferrer';
+      props.rel = `${props.rel ? props.rel : ''} noopener noreferrer`.trim();
     }
 
     delete props.eventLabel;

--- a/test/components/OutboundLink.test.jsx
+++ b/test/components/OutboundLink.test.jsx
@@ -113,4 +113,19 @@ describe('<OutboundLink> React component', () => {
     );
     expect(renderedOutboundLink.prop('rel')).toEqual('noopener noreferrer');
   });
+
+  it('should add custom rel tags if the target is _blank', () => {
+    const destinationUrl = 'http://example.com/';
+    renderedOutboundLink = shallow(
+      <OutboundLink
+        to={destinationUrl}
+        eventLabel=""
+        target="_blank"
+        rel="nofollow"
+      />
+    );
+    expect(renderedOutboundLink.prop('rel')).toEqual(
+      'nofollow noopener noreferrer'
+    );
+  });
 });


### PR DESCRIPTION
Fixes #416 

Adds the ability to pass custom rel tags even when the target is set to `_blank`

Usage:
```
 <OutboundLink
        to='http://blah.com'
        eventLabel=""
        target="_blank"
        rel="nofollow"
      />
```
Will append `nofollow` to the `noopener noreferrer`. This allows the ability to pass whatever rel tag that you want and it be included 