### PR TITLE
Corrected some outdated GA information

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This is a JavaScript module that can be used to include Google Analytics tracking code in a website or app that uses [React](https://facebook.github.io/react/) for its front-end codebase. It does not currently use any React code internally, but has been written for use with a number of Mozilla Foundation websites that are using React, as a way to standardize our GA Instrumentation across projects.
 
-It is designed to work with the latest version of Google Analytics, [Universal Analytics](https://support.google.com/analytics/answer/2790010). At this point, all Google Analytics projects are being upgraded to Universal Analytics, so this module will not support the older `ga.js` implementation.
+It is designed to work with, [Universal Analytics](https://support.google.com/analytics/answer/2790010) and will not support the older `ga.js` implementation.
 
 This module is mildly opinionated in how we instrument tracking within our front-end code. Our API is slightly more verbose than the core Google Analytics library, in the hope that the code is easier to read and understand for our engineers. See examples below.
 


### PR DESCRIPTION
In the Readme it previously referred to Universal Analytics as the latest version of GA.  
However, since the introduction of Google Analytics 4, this is no longer the case.  
This wording has been updated so that it more accurately reflects the current GA releases.

closes #472