### PR TITLE
Do not count undefined as an argument of execute.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -471,7 +471,7 @@ export const plugin = {
     let payload;
     let actionType;
 
-    if (args.length === 1) {
+    if (args.filter(Boolean).length === 1) {
       [payload] = args;
     } else {
       [actionType, payload] = args;


### PR DESCRIPTION
# issue
When I pass payload as the 3rd argument and undefined as the 4th argument of `excute`, 
line 504 of `core.js` is evaluated.

## now
``` 
ReactGA.plugin.execute('ec', 'addProduct', { id: ~, name: ~ }, undefined)

then ↓

ReactGA.ga('ec', 'addProduct')
```

## after this pr merged
``` 
ReactGA.plugin.execute('ec', 'addProduct', { id: ~, name: ~ }, undefined)

then ↓

ReactGA.ga('ec', 'addProduct', { id: ~, name: ~ })
```